### PR TITLE
Fixes #19 Channel logs exceeding maximum message length

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ In order for the bot to work you need to provide proper configuration for it. To
 
 ### Note about discord channel logging
 
-Although posting internal logs directly to a discord channel has it's usefulness in that you can quickly determine if something's wrong, it should be used with some caution. First and foremost especially on active servers log messages posted to a Discord channel may contribute to exceeding the Discord gateways rate limiting for your application. Furthermore logging to a discord channel will only work during the applications gateway uptime. Log events that take place during the gateways downtime will be added to a queue by default so they can be posted once the gateway is up again. 
+Although posting internal logs directly to a discord channel has it's usefulness in that you can quickly determine if something's wrong, it should be used with some caution. First and foremost especially on active servers log messages posted to a Discord channel may contribute to exceeding the Discord gateways rate limiting for your application. Furthermore logging to a discord channel will only work during the applications gateway uptime. Log events that take place during the gateways downtime will be added to a queue by default so they can be posted once the gateway is up again however in certain events that may not happen. Lastly log messages that exceed the maximum message length (currently `2000` characters) aren't split up into parts but instead not sent at all.
 
 ## Self hosting
 

--- a/src/Hainz/Services/Logging/DiscordChannelLoggerService.cs
+++ b/src/Hainz/Services/Logging/DiscordChannelLoggerService.cs
@@ -71,15 +71,7 @@ public sealed class DiscordChannelLoggerService : IGatewayService
             {
                 await foreach (var logMessage in _logQueue.ReceiveAllAsync(ct)) 
                 {
-                    if (_currentLogMessage != null)
-                    {
-                       await AppendToLogAsync(_currentLogMessage, logMessage);
-                    }
-                    else
-                    {
-                        var message = Format.Code(logMessage, "css");
-                        _currentLogMessage = await _logChannel!.SendMessageAsync(message);
-                    }
+                    await AppendToLogAsync(logMessage);
                 }
             }
             catch (Exception ex)
@@ -89,13 +81,40 @@ public sealed class DiscordChannelLoggerService : IGatewayService
         }
     }
 
-    private static async Task AppendToLogAsync(RestUserMessage message, string logMessage) 
+    private async Task AppendToLogAsync(string logMessage) 
     {
-        await message.ModifyAsync(msg => 
+        if (_currentLogMessage == null || 
+            logMessage.Length + _currentLogMessage.Content.Length + 1 > DiscordConfig.MaxMessageSize)
         {
-            var content = message.Content;
-            int lastLogIndex = content.LastIndexOf('\n');
-            msg.Content = content.Insert(lastLogIndex + 1, logMessage + "\n");
-        });
+            await WriteAsNewMessageAsync(logMessage);
+        }
+        else
+        {
+            await _currentLogMessage.ModifyAsync(msg => 
+            {
+                var content = _currentLogMessage.Content;
+                int lastLogIndex = content.LastIndexOf('\n');
+                msg.Content = content.Insert(lastLogIndex + 1, logMessage + "\n");
+            });
+        }
+    }
+
+    private async Task WriteAsNewMessageAsync(string logMessage)
+    {
+        logMessage = Format.Code(logMessage, "css");
+
+        if (logMessage.Length > DiscordConfig.MaxMessageSize)
+        {
+            // Note: Although the message could be split and send in separate parts we decided not to do that.
+            _logger.LogWarning("Not logging log message to Discord channel because content length of {contentSize} exceeds maximum length {maximumLength}", logMessage.Length, DiscordConfig.MaxMessageSize);
+        }
+        else
+        {
+            MessageReference? oldLogMessageReference = null;
+            if (_currentLogMessage != null)
+                oldLogMessageReference = new MessageReference(_currentLogMessage.Id);
+
+            _currentLogMessage = await _logChannel!.SendMessageAsync(logMessage, messageReference: oldLogMessageReference);   
+        }
     }
 }

--- a/src/Hainz/Services/Logging/DiscordChannelLoggerService.cs
+++ b/src/Hainz/Services/Logging/DiscordChannelLoggerService.cs
@@ -82,7 +82,10 @@ public sealed class DiscordChannelLoggerService : IGatewayService
                     }
                 }
             }
-            catch { }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Exception in LogWriter task");
+            }
         }
     }
 

--- a/src/Hainz/nlog.release.config
+++ b/src/Hainz/nlog.release.config
@@ -12,6 +12,7 @@
   </targets>
   <rules>
     <logger name="Microsoft.*" maxlevel="Info" writeTo="" final="true" />
+    <logger name="Hainz.Services.Logging.DiscordChannelLoggerService" minlevel="Info" writeTo="console, file" final="true" />
     <logger name="*" minlevel="Info" writeTo="console, file, discord" />
   </rules>
 </nlog>


### PR DESCRIPTION
- `DiscordChannelLoggerService` now has internal logs that are only written to console and file targets
- Log messages that exceed the current Discord log message are put into a new message referencing the old one
- Log messages that by themselves are too long to fit in a single message are not sent at all. In this case a warning is being logged